### PR TITLE
Resolve connection failures for FTDI serial ports

### DIFF
--- a/gui/usb_interface.py
+++ b/gui/usb_interface.py
@@ -79,7 +79,7 @@ class USBInterface(QObject):
         try:
             dev_info = None
             for info in QSerialPortInfo.availablePorts():
-                if ((info.manufacturer() == 'Digilent') and
+                if ((info.manufacturer() in ('Digilent', 'FTDI')) and
                     (info.hasVendorIdentifier() and info.vendorIdentifier() == 0x0403) and
                     (info.hasProductIdentifier() and info.productIdentifier() == 0x6010)):
                     dev_info = info

--- a/gui/usb_interface.py
+++ b/gui/usb_interface.py
@@ -98,8 +98,8 @@ class USBInterface(QObject):
             # Mark ourselves connected
             self.connected.emit(True)
 
-        except:
-            pass
+        except Exception as e:
+            print(e)
 
     def _error(self, error):
         print(error)


### PR DESCRIPTION
In my environment, the DSKY and AGC Monitor would launch but no UI action would materially change any state.

Printing exceptions raised during connection attempts clarified that the board and USB cable combo did not return the expected info, and the application would then loop back to retry the connection.  The lack of state change is due to repeating failures to connect to the FPGA device.

Expanding the list of supported serial port manufacturers to include "FTDI" was sufficient for my system to connect to the configured FPGA and present a usable DSKY and AGC Monitor. No change to the vendor and product identifiers was necessary.